### PR TITLE
make autotrack scan after success/fail instead of every 5 seconds

### DIFF
--- a/script.js
+++ b/script.js
@@ -188,7 +188,7 @@ function getPokemon(lat, lng) {
             } else {
                 $(".nearby").hide();
             }
-
+	    autoTrack();
         },
         timeout: 50000        
     }).fail( function( xhr, status ) {
@@ -207,6 +207,7 @@ function getPokemon(lat, lng) {
                 currfailure = null;
             }
         }, 1500); // Hide status color after 1,5 seconds
+        autoTrack();
     });
 }
 
@@ -472,8 +473,7 @@ $(function() {
     });
     
     setInterval(updateTime, 1000);
-    setInterval(autoTrack,  5000);
-    
+
     /* Start Scan */
     $('.scan').on('click', function() {
         if(!$('.scan').hasClass('active')) {


### PR DESCRIPTION
Autotrack is tracking every 5 seconds without knowing if it makes sense right now due to an active scan .. 

Also the coutner is running, even if autotrack is disabled ... that may make FPM a tiny bit less CPU intensive, i would say ;)
